### PR TITLE
use default cmap

### DIFF
--- a/params/brain_plot_params.yaml
+++ b/params/brain_plot_params.yaml
@@ -1,5 +1,4 @@
 views: ['lat', 'med', 'ven']
 hemi: 'split'
 size: [640, 1600]
-colormap: 'cool'
 subjects_dir: '/mnt/scratch/prek/anat'


### PR DESCRIPTION
Passing a specific colormap ('cool') was truncating the negative values for the condition contrast and pre-vs-post contrast movies. This will let MNE-Python pick a diverging colormap automatically when the data demands it.  cc @jyeatman 